### PR TITLE
Added preview of Print Shop Graphics

### DIFF
--- a/src/com/bytezone/diskbrowser/applefile/PrintShopGraphic.java
+++ b/src/com/bytezone/diskbrowser/applefile/PrintShopGraphic.java
@@ -1,0 +1,43 @@
+package com.bytezone.diskbrowser.applefile;
+
+import java.awt.AlphaComposite;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBuffer;
+
+public class PrintShopGraphic extends AbstractFile
+{
+  public PrintShopGraphic (String name, byte[] buffer)
+  {
+    super (name, buffer);
+
+    image = new BufferedImage (88, 52, BufferedImage.TYPE_BYTE_GRAY);
+    Graphics2D g2d = image.createGraphics ();
+    g2d.setComposite (AlphaComposite.getInstance (AlphaComposite.SRC_OVER, (float) 1.0));
+    DataBuffer dataBuffer = image.getRaster ().getDataBuffer ();
+    int element = 0;
+
+    for (int ptr = 0; ptr < 572; ptr++)
+    {
+        for (int px = 7; px >= 0; px--)
+        {
+          int val = (buffer[ptr] >> px) & 0x01;
+          dataBuffer.setElem (element++, val == 0 ? 255 : 0);
+        }
+    }
+    
+    g2d.dispose ();
+  }
+
+  @Override
+  public String getText ()
+  {
+    StringBuilder text = new StringBuilder ();
+
+    text.append (String.format ("File Name      : %s%n", name));
+    text.append (String.format ("File size      : %,d%n", buffer.length));
+
+    return text.toString ();
+  }
+
+}

--- a/src/com/bytezone/diskbrowser/dos/AbstractCatalogEntry.java
+++ b/src/com/bytezone/diskbrowser/dos/AbstractCatalogEntry.java
@@ -228,6 +228,8 @@ abstract class AbstractCatalogEntry implements AppleFileSource
             else
               appleFile = new AssemblerProgram (name, exactBuffer, loadAddress);
           }
+          else if ((loadAddress == 0x5800 || loadAddress == 0x7800) && reportedLength == 0x240)
+        	  appleFile = new PrintShopGraphic(name, exactBuffer);
           else
           {
             appleFile = new AssemblerProgram (name, exactBuffer, loadAddress);


### PR DESCRIPTION
Print shop graphics are small graphics of 88 x 52 pixels.

Because of its popularity many clip art libraries exist and even
disk magazines bundled images in most of its issues.

Browsing them on an emulator can take forever and often the file names
were not very descriptive. DiskBrowser is the perfect alternative since
it allows for a quick preview of any file.